### PR TITLE
Optionally use a K8s Service Account (useful for IRSA in EKS)

### DIFF
--- a/charts/rqlite/templates/_statefulset.tpl
+++ b/charts/rqlite/templates/_statefulset.tpl
@@ -49,8 +49,12 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      # rqlite doesn't require the K8s API
+      {{- if $.Values.serviceAccount.name }}
+      serviceAccountName: {{ $.Values.serviceAccount.name }}
+      {{- else }}
       automountServiceAccountToken: false
+      {{- end }}
+
       terminationGracePeriodSeconds: {{ dig "terminationGracePeriodSeconds" $.Values.terminationGracePeriodSeconds $values }}
 
       {{- with dig "podSecurityContext" $.Values.podSecurityContext $values }}

--- a/charts/rqlite/templates/serviceaccount.yaml
+++ b/charts/rqlite/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if dig "serviceAccount" "create" false .Values.AsMap }}
+{{- $name := dig "serviceAccount" "name" "" .Values.AsMap -}}
+{{- if empty $name }}
+  {{- fail "serviceAccount.name must be defined when serviceAccount.create is true" }}
+{{- end }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $name }}
+  {{- with dig "serviceAccount" "annotations" dict .Values.AsMap }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "rqlite.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/rqlite/values.yaml
+++ b/charts/rqlite/values.yaml
@@ -112,6 +112,29 @@ podSecurityContext:
 securityContext: {}
 
 
+# Configures the K8s Service Account for rqlite pods. rqlite doesn't use the K8s API, so
+# by default a service account is neither created nor used. However, if you're using
+# automatic backup/restore (see config.backup below) and the chart is deployed on EKS in
+# AWS, you will probably want to use an IAM Role for Service Accounts (IRSA):
+#
+# https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
+#
+# IRSA allows rqlite to access the S3 bucket for backup/restore without configuring static
+# credentials.
+serviceAccount:
+  # If true, the chart will create a ServiceAccount resource, in which case the "name"
+  # must be set below otherwise the chart will error. Set this to false if rqlite should
+  # not use service account (the default), or if you're precreating your own
+  # ServiceAccount (for example because you used Terraform to create an IRSA role and
+  # corresponding K8s Service Account).
+  create: false
+  # The name of the service account to use for rqlite pods. If this is empty, then
+  # no service account will be used by rqlite pods.
+  name: ""
+  # Custom annotations to add to the ServiceAccount
+  annotations: {}
+
+
 # Persistent Volume configuration.
 #
 # This value is inherited by read-only nodes but may be overridden (see "readonly" below).


### PR DESCRIPTION
Thanks to rqlite/rqlite#1578 there is now a use case for rqlite to run under a K8s Service Account.