### PR TITLE
Add support for arm, arm64, and 386 architectures

### DIFF
--- a/charts/rqlite/values.yaml
+++ b/charts/rqlite/values.yaml
@@ -166,18 +166,12 @@ tolerations: []
 #
 # https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/
 #
-# The default chart value ensures rqlite is only scheduled on amd64 nodes. This is because
-# rqlite's image on Docker Hub currently only supports amd64, so scheduling rqlite pods on
-# other architectures will only result in CrashLoopBackoff.
+# The default chart value ensures pods are only scheduled on nodes with architectures
+# supported by rqlite's official container image.
 #
-# If you're using your own non-amd64 container images, then in addition to updating the
-# image map above, you will also need to replace the affinity field to override the chart
-# default. (Reminder that setting a Helm map value to null will override the chart
-# default. If you specify a map value it will be merged, which may not be the desired
-# outcome.)
-#
-# Once rqlite supports multi-arch images this will be updated accordingly.  See also
-# https://github.com/rqlite/rqlite/issues/1077
+# If you've build your own custom rqlite image for other architectures, then in addition
+# to updating the image map above, you will also need to replace the affinity field to
+# override the chart default.
 #
 # This value is inherited by read-only nodes but may be overridden (see "readonly" below).
 affinity:
@@ -189,6 +183,9 @@ affinity:
             operator: In
             values:
               - amd64
+              - "386"
+              - arm
+              - arm64
 
 # Topology spread constraints influence how pods are scheduled across the cluster.
 #


### PR DESCRIPTION
As of 8.24.9, rqlite supports multi-arch images. This updates the node affinity selector to include all architectures supported by the official container image.

Fixes #24