### PR TITLE
Default to rqlite 8.26.8

### DIFF
--- a/charts/rqlite/Chart.yaml
+++ b/charts/rqlite/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: rqlite
 version: 1.10.0
-appVersion: 8.26.0
+appVersion: 8.26.8
 description: The lightweight, distributed relational database built on SQLite
 type: application
 home: https://rqlite.io/


### PR DESCRIPTION
There was bad bug in timestamped S3 uploads, folks should run this version.