### PR TITLE
Default release should be 8.30.5

### DIFF
--- a/charts/rqlite/Chart.yaml
+++ b/charts/rqlite/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: rqlite
 version: 1.11.0
-appVersion: 8.26.8
+appVersion: 8.30.5
 description: The lightweight, distributed relational database built on SQLite
 type: application
 home: https://rqlite.io/


### PR DESCRIPTION
There is a potential data loss scenario in earlier releases. 8.30.5 fixes it.