### PR TITLE
Preserve backward compatibility for backup endpoint

### DIFF
--- a/charts/rqlite/templates/secret.yaml
+++ b/charts/rqlite/templates/secret.yaml
@@ -21,6 +21,15 @@ user-suppplied list below
       "path" (dig "backup" "storage" "path" nil $config)
       "force_path_style" (dig "backup" "storage" "forcePathStyle" false $config)
 }}
+{{- if and $backupStorage.endpoint (not (contains "://" $backupStorage.endpoint)) }}
+  {{/*
+  As part of the upgrade to AWS SDK v2 in rqlite v8.29.3, the endpoint now must be
+  specified as a URI rather than a straight FQDN. This is a breaking change, but rather
+  than bumping the major version of the chart to reflect the incompatibility, we just
+  prepend "https://" to the endpoint if it doesn't already contain a scheme.
+  */}}
+  {{- $_ := set $backupStorage "endpoint" (printf "https://%s" $backupStorage.endpoint) }}
+{{- end }}
 {{- $backup := dict }}
 {{- $restore := dict }}
 {{- if dig "backup" "autoBackup" "enabled" false $config }}


### PR DESCRIPTION
v8.29.3 introduced a breaking change that requires the backup endpoint to be a URI rather than a straight FQDN. This fix will transform the endpoint from the chart value to the required URI format if necessary. This preserves compatibility with previous rqlite chart versions.